### PR TITLE
修复Tornado3.0不支持 tornado.database bug

### DIFF
--- a/application.py
+++ b/application.py
@@ -15,7 +15,7 @@ sys.setdefaultencoding("utf8")
 import os.path
 import re
 import memcache
-import tornado.database
+import torndb
 import tornado.httpserver
 import tornado.ioloop
 import tornado.options
@@ -85,7 +85,7 @@ class Application(tornado.web.Application):
         tornado.web.Application.__init__(self, handlers, **settings)
 
         # Have one global connection to the blog DB across all handlers
-        self.db = tornado.database.Connection(
+        self.db = torndb.Connection(
             host = options.mysql_host, database = options.mysql_database,
             user = options.mysql_user, password = options.mysql_password
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 tornado
+torndb
 jinja2
 markdown
 pygments


### PR DESCRIPTION
我在本地部署并安装对应模块，在启动时会提示 `tornado.database`错误。

参照这个[帖子](http://stackoverflow.com/questions/15938260/tornado-database-importerror-no-module-named-database)升级后运行正常。

原因在于tornado 3.0废弃了`tornado.database`模块，替换为`torndb`即可。
